### PR TITLE
Add Sanity Studio scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Sanity Studio configuration
+SANITY_STUDIO_PROJECT_ID=
+SANITY_STUDIO_DATASET=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# Platinum Development Website
+
+This repository contains the marketing site for Platinum Development along with a Sanity Studio for managing hero, about, portfolio, and contact content.
+
+## Prerequisites
+
+- Node.js 18 or newer
+- npm 9 or newer
+- A Sanity project with an existing dataset
+
+Copy `.env.example` to `.env` and set the following environment variables:
+
+```bash
+SANITY_STUDIO_PROJECT_ID=yourProjectId
+SANITY_STUDIO_DATASET=yourDataset
+```
+
+## Installation
+
+Install dependencies (the Sanity CLI is included as a dev dependency):
+
+```bash
+npm install
+```
+
+> If installation fails because the Sanity packages cannot be downloaded, double-check your network access or npm registry configuration.
+
+## Sanity Studio
+
+The Studio is located in the `sanity/` directory and is configured with custom document types and desk structure for:
+
+- Homepage hero content
+- About section content
+- Portfolio projects
+- Contact information
+
+### Local development
+
+```bash
+npm run sanity dev
+```
+
+The command starts the Sanity Studio on [http://localhost:3333](http://localhost:3333).
+
+### Deploying the Studio
+
+```bash
+npm run sanity deploy
+```
+
+Deploying the Studio requires you to be authenticated with Sanity (`npm run sanity login`).
+
+### Additional commands
+
+```bash
+npm run sanity login   # Authenticate with Sanity
+npm run sanity manage  # Open the Sanity project settings in the browser
+```
+
+## Project structure
+
+```
+.
+├── index.html
+├── sanity/
+│   ├── env.d.ts
+│   ├── sanity.cli.ts
+│   ├── sanity.config.ts
+│   ├── schemaTypes/
+│   │   ├── about.ts
+│   │   ├── contact.ts
+│   │   ├── hero.ts
+│   │   └── portfolio.ts
+│   └── structure/
+│       └── deskStructure.ts
+└── vegas2.jpg
+```
+
+## Deployment
+
+Refer to the Sanity documentation for configuring hosting and connecting the Studio to your preferred deployment platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,17 @@
 {
-  "name": "PlatinumDevelopmentWebsite",
+  "name": "platinumdevelopmentwebsite",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "platinumdevelopmentwebsite",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@sanity/vision": "^3.58.0",
+        "sanity": "^3.58.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.0"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "platinumdevelopmentwebsite",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Marketing site and Sanity Studio for Platinum Development.",
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  },
+  "scripts": {
+    "sanity": "sanity",
+    "sanity dev": "sanity dev",
+    "sanity build": "sanity build",
+    "sanity deploy": "sanity deploy",
+    "sanity login": "sanity login",
+    "sanity manage": "sanity manage"
+  },
+  "keywords": [
+    "sanity",
+    "cms",
+    "platinum-development"
+  ],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@sanity/vision": "^3.58.0",
+    "sanity": "^3.58.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/sanity/env.d.ts
+++ b/sanity/env.d.ts
@@ -1,0 +1,6 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    SANITY_STUDIO_PROJECT_ID?: string
+    SANITY_STUDIO_DATASET?: string
+  }
+}

--- a/sanity/sanity.cli.ts
+++ b/sanity/sanity.cli.ts
@@ -1,0 +1,19 @@
+import {defineCliConfig} from 'sanity/cli'
+
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID
+const dataset = process.env.SANITY_STUDIO_DATASET
+
+if (!projectId) {
+  throw new Error('Missing SANITY_STUDIO_PROJECT_ID environment variable')
+}
+
+if (!dataset) {
+  throw new Error('Missing SANITY_STUDIO_DATASET environment variable')
+}
+
+export default defineCliConfig({
+  api: {
+    projectId,
+    dataset,
+  },
+})

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -1,0 +1,34 @@
+import {defineConfig} from 'sanity'
+import {deskTool} from 'sanity/desk'
+import {visionTool} from '@sanity/vision'
+
+import deskStructure, {defaultDocumentNode} from './structure/deskStructure'
+import schemaTypes from './schemaTypes'
+
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID
+const dataset = process.env.SANITY_STUDIO_DATASET
+
+if (!projectId) {
+  throw new Error('Missing SANITY_STUDIO_PROJECT_ID environment variable')
+}
+
+if (!dataset) {
+  throw new Error('Missing SANITY_STUDIO_DATASET environment variable')
+}
+
+export default defineConfig({
+  name: 'platinum_development_studio',
+  title: 'Platinum Development Studio',
+  projectId,
+  dataset,
+  plugins: [
+    deskTool({
+      structure: deskStructure,
+      defaultDocumentNode,
+    }),
+    visionTool(),
+  ],
+  schema: {
+    types: schemaTypes,
+  },
+})

--- a/sanity/schemaTypes/about.ts
+++ b/sanity/schemaTypes/about.ts
@@ -1,0 +1,60 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'about',
+  title: 'About',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Section Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'intro',
+      title: 'Introduction',
+      type: 'text',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'services',
+      title: 'Services',
+      type: 'array',
+      of: [
+        defineField({
+          name: 'service',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'name',
+              title: 'Service Name',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
+              name: 'description',
+              title: 'Description',
+              type: 'text',
+            }),
+          ],
+        }),
+      ],
+    }),
+    defineField({
+      name: 'highlightImage',
+      title: 'Highlight Image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: 'About Section',
+      }
+    },
+  },
+})

--- a/sanity/schemaTypes/contact.ts
+++ b/sanity/schemaTypes/contact.ts
@@ -1,0 +1,68 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'contact',
+  title: 'Contact',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Section Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'email',
+      title: 'Email',
+      type: 'string',
+      validation: (Rule) => Rule.email(),
+    }),
+    defineField({
+      name: 'phone',
+      title: 'Phone Number',
+      type: 'string',
+    }),
+    defineField({
+      name: 'address',
+      title: 'Address',
+      type: 'text',
+    }),
+    defineField({
+      name: 'socialLinks',
+      title: 'Social Links',
+      type: 'array',
+      of: [
+        defineField({
+          name: 'socialLink',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'platform',
+              title: 'Platform',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
+              name: 'url',
+              title: 'URL',
+              type: 'url',
+              validation: (Rule) => Rule.required(),
+            }),
+          ],
+        }),
+      ],
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Contact Information',
+      }
+    },
+  },
+})

--- a/sanity/schemaTypes/hero.ts
+++ b/sanity/schemaTypes/hero.ts
@@ -1,0 +1,46 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'hero',
+  title: 'Hero',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'headline',
+      title: 'Headline',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'subheadline',
+      title: 'Subheadline',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'ctaLabel',
+      title: 'Primary CTA Label',
+      type: 'string',
+    }),
+    defineField({
+      name: 'ctaUrl',
+      title: 'Primary CTA URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'backgroundImage',
+      title: 'Background Image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Homepage Hero',
+      }
+    },
+  },
+})

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,0 +1,8 @@
+import about from './about'
+import contact from './contact'
+import hero from './hero'
+import portfolio from './portfolio'
+
+const schemaTypes = [hero, about, portfolio, contact]
+
+export default schemaTypes

--- a/sanity/schemaTypes/portfolio.ts
+++ b/sanity/schemaTypes/portfolio.ts
@@ -1,0 +1,74 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'portfolio',
+  title: 'Portfolio Project',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Project Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+    }),
+    defineField({
+      name: 'summary',
+      title: 'Summary',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'description',
+      title: 'Detailed Description',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'block',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+    }),
+    defineField({
+      name: 'gallery',
+      title: 'Gallery Images',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'image',
+          options: {hotspot: true},
+        }),
+      ],
+    }),
+    defineField({
+      name: 'techStack',
+      title: 'Tech Stack',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'projectUrl',
+      title: 'Project URL',
+      type: 'url',
+    }),
+  ],
+})

--- a/sanity/structure/deskStructure.ts
+++ b/sanity/structure/deskStructure.ts
@@ -1,0 +1,29 @@
+import type {StructureBuilder} from 'sanity/desk'
+
+const singletonTypes = ['hero', 'about', 'contact']
+
+export const deskStructure = (S: StructureBuilder) =>
+  S.list()
+    .title('Content')
+    .items([
+      ...singletonTypes.map((typeName) =>
+        S.listItem()
+          .title(typeName.charAt(0).toUpperCase() + typeName.slice(1))
+          .child(
+            S.document()
+              .schemaType(typeName)
+              .documentId(typeName)
+          )
+      ),
+      S.divider(),
+      S.documentTypeListItem('portfolio').title('Portfolio Projects'),
+      ...S.documentTypeListItems().filter(
+        (listItem) => ![...singletonTypes, 'portfolio'].includes(listItem.getId() || '')
+      ),
+    ])
+
+export const defaultDocumentNode = (S: StructureBuilder) => {
+  return S.document().views([S.view.form()])
+}
+
+export default deskStructure

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["sanity"],
+    "baseUrl": "."
+  },
+  "include": ["sanity/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Sanity Studio configuration with hero, about, portfolio, and contact schemas
- introduce custom desk structure and CLI configuration that rely on project environment variables
- document setup steps, environment requirements, and Sanity Studio commands

## Testing
- npm install *(fails: 403 Forbidden when downloading Sanity packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c9ffabc483318b586d0cd37fd9dc