### PR TITLE
Load Sanity Studio config without Node-only APIs

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,0 +1,2 @@
+export {default} from './sanity/sanity.cli'
+export * from './sanity/sanity.cli'

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,0 +1,2 @@
+export {default} from './sanity/sanity.config'
+export * from './sanity/sanity.config'

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -1,4 +1,3 @@
-import {createRequire} from 'module'
 import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {visionTool} from '@sanity/vision'
@@ -6,27 +5,45 @@ import {visionTool} from '@sanity/vision'
 import deskStructure, {defaultDocumentNode} from './structure/deskStructure'
 import schemaTypes from './schemaTypes'
 
-const require = createRequire(import.meta.url)
-
-let localProjectId: string | undefined
-let localDataset: string | undefined
-
-try {
-  const cfg = require('../client-config.js') as {
-    projectId?: string
-    dataset?: string
-    default?: {projectId?: string; dataset?: string}
-    sanityConfig?: {projectId?: string; dataset?: string}
-  }
-  const resolved = cfg.sanityConfig || cfg.default || cfg
-  localProjectId = resolved.projectId
-  localDataset = resolved.dataset
-} catch (error) {
-  // Optional client-config.js not found; ignore
+type ClientConfigModule = {
+  projectId?: string
+  dataset?: string
+  default?: {projectId?: string; dataset?: string}
+  sanityConfig?: {projectId?: string; dataset?: string}
 }
 
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || localProjectId
-const dataset = process.env.SANITY_STUDIO_DATASET || localDataset
+async function loadLocalClientConfig(): Promise<{
+  projectId?: string
+  dataset?: string
+} | undefined> {
+  try {
+    const module = (await import('../client-config.js')) as ClientConfigModule
+    return module.sanityConfig || module.default || module
+  } catch (error) {
+    // Optional client-config.js not found; ignore
+    return undefined
+  }
+}
+
+function readEnvVariable(key: 'SANITY_STUDIO_PROJECT_ID' | 'SANITY_STUDIO_DATASET') {
+  if (typeof process !== 'undefined' && process.env?.[key]) {
+    return process.env[key]
+  }
+
+  if (typeof import.meta !== 'undefined') {
+    const env = (import.meta as {env?: Record<string, string | undefined>}).env
+    if (env?.[key]) {
+      return env[key]
+    }
+  }
+
+  return undefined
+}
+
+const localConfig = await loadLocalClientConfig()
+
+const projectId = readEnvVariable('SANITY_STUDIO_PROJECT_ID') || localConfig?.projectId
+const dataset = readEnvVariable('SANITY_STUDIO_DATASET') || localConfig?.dataset
 
 if (!projectId) {
   throw new Error(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "types": ["sanity"],
     "baseUrl": "."
   },
-  "include": ["sanity/**/*.ts"],
+  "include": ["sanity/**/*.ts", "sanity.config.ts", "sanity.cli.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- resolve the optional client configuration with a dynamic import so the Studio config no longer depends on Node-only modules
- read the Sanity credentials from either environment variables or the optional client-config.js fallback while keeping existing validation

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'sanity')*

------
https://chatgpt.com/codex/tasks/task_e_68d2e4f84430833186a86a32dc94a925