### PR TITLE
Center portfolio cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,8 @@
             }
             .portfolio-carousel__track {
                 gap: 1.25rem;
-                padding-right: 1rem;
+                padding-left: max(calc((100vw - 82vw) / 2), 1rem);
+                padding-right: max(calc((100vw - 82vw) / 2), 1rem);
             }
             .carousel-button {
                 display: none;


### PR DESCRIPTION
## Summary
- adjust mobile carousel track padding so the first card starts centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4aea5ec6483318fbfc379ea797ea3