### PR TITLE
Center portfolio cards on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,14 @@
                 scroll-padding-left: var(--carousel-side-padding);
                 scroll-padding-right: var(--carousel-side-padding);
             }
+            .portfolio-carousel__track::before,
+            .portfolio-carousel__track::after {
+                content: none;
+                flex: 0 0 auto;
+            }
+            .portfolio-card {
+                scroll-snap-align: center;
+            }
         }
         .carousel-button {
             display: inline-flex;


### PR DESCRIPTION
## Summary
- remove the flex-based spacer elements for the portfolio carousel on small screens so the cards can center within the viewport
- center each portfolio card in the mobile snap carousel for a more balanced presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4c553adc4833194c362d63a232516