### PR TITLE
Fix asset path resolution for subdirectory deployments

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@
             }
             try {
                 const resolvedUrl = new URL(url, window.location.href);
-                return resolvedUrl.pathname + resolvedUrl.search + resolvedUrl.hash;
+                return resolvedUrl.href;
             } catch (error) {
                 console.warn('Failed to resolve asset path, using original value.', error);
                 return url;


### PR DESCRIPTION
## Summary
- ensure resolveAssetPath returns the full resolved URL instead of only the pathname
- confirm hero and CMS image helpers continue to consume resolveAssetPath for consistent asset loading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daec677808833182c97f7b9b4c0dd4